### PR TITLE
STRING_BYTES column in HSQL: use VARBINARY type instead of BINARY.

### DIFF
--- a/src/main/java/com/j256/ormlite/db/HsqldbDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/HsqldbDatabaseType.java
@@ -41,12 +41,12 @@ public class HsqldbDatabaseType extends BaseDatabaseType implements DatabaseType
 
 	@Override
 	protected void appendByteArrayType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
-		sb.append("VARBINARY(255)");
+		sb.append("VARBINARY(").append(fieldWidth).append(")");
 	}
 
 	@Override
 	protected void appendSerializableType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
-		sb.append("VARBINARY(255)");
+		appendByteArrayType(sb, fieldType, fieldWidth);
 	}
 
 	@Override


### PR DESCRIPTION
according to 
http://hsqldb.org/doc/guide/sqlgeneral-chapt.html#sgc_binary_types
BINARY is a very short thing.
