### PR TITLE
Support MariaDB

### DIFF
--- a/src/main/java/com/j256/ormlite/db/DatabaseTypeUtils.java
+++ b/src/main/java/com/j256/ormlite/db/DatabaseTypeUtils.java
@@ -21,6 +21,7 @@ public class DatabaseTypeUtils {
 		databaseTypes.add(new H2DatabaseType());
 		databaseTypes.add(new HsqldbDatabaseType());
 		databaseTypes.add(new MysqlDatabaseType());
+		databaseTypes.add(new MariaDbDatabaseType());
 		databaseTypes.add(new NetezzaDatabaseType());
 		databaseTypes.add(new OracleDatabaseType());
 		databaseTypes.add(new PostgresDatabaseType());

--- a/src/main/java/com/j256/ormlite/db/MariaDbDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/MariaDbDatabaseType.java
@@ -1,0 +1,94 @@
+package com.j256.ormlite.db;
+
+import com.j256.ormlite.field.FieldType;
+
+import java.util.List;
+
+/**
+ * MariaDB database type information used to create the tables, etc..
+ * 
+ * <p>
+ * <b>NOTE:</b> By default the tables are created with the ENGINE=InnoDB suffix (see
+ * {@link #DEFAULT_CREATE_TABLE_SUFFIX}. Use {@link #setCreateTableSuffix} to change that to "" to use the default
+ * MyISAM storage engine, to choose another engine, or set other settings. For more information about engines, see the
+ * 'SHOW ENGINES;' results from the MariaDB command line tool.
+ * </p>
+ * 
+ * @author graywatson
+ */
+public class MariaDbDatabaseType extends BaseDatabaseType {
+
+	private final static String DATABASE_URL_PORTION = "mariadb";
+	private final static String DRIVER_CLASS_NAME = "org.mariadb.jdbc.Driver";
+	private final static String DATABASE_NAME = "MariaDB";
+
+	/**
+	 * Default suffix to the CREATE TABLE statement. Change with the {@link #setCreateTableSuffix} method.
+	 */
+	public final static String DEFAULT_CREATE_TABLE_SUFFIX = "ENGINE=InnoDB";
+
+	private String createTableSuffix = DEFAULT_CREATE_TABLE_SUFFIX;
+
+	public boolean isDatabaseUrlThisType(String url, String dbTypePart) {
+		return DATABASE_URL_PORTION.equals(dbTypePart);
+	}
+
+	@Override
+	protected String getDriverClassName() {
+		return DRIVER_CLASS_NAME;
+	}
+
+	public String getDatabaseName() {
+		return DATABASE_NAME;
+	}
+
+	/**
+	 * Set the string that is appended to the end of a CREATE TABLE statement.
+	 */
+	public void setCreateTableSuffix(String createTableSuffix) {
+		this.createTableSuffix = createTableSuffix;
+	}
+
+	@Override
+	protected void appendDateType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
+		/**
+		 * TIMESTAMP in MariaDB does some funky stuff with the last-modification time. Values are 'not null' by default
+		 * with an automatic default of CURRENT_TIMESTAMP. Strange design decision.
+		 */
+		sb.append("DATETIME");
+	}
+
+	@Override
+	protected void appendBooleanType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
+		sb.append("TINYINT(1)");
+	}
+
+	@Override
+	protected void configureGeneratedId(String tableName, StringBuilder sb, FieldType fieldType,
+			List<String> statementsBefore, List<String> statementsAfter, List<String> additionalArgs,
+			List<String> queriesAfter) {
+		sb.append("AUTO_INCREMENT ");
+		configureId(sb, fieldType, statementsBefore, additionalArgs, queriesAfter);
+	}
+
+	@Override
+	public void appendCreateTableSuffix(StringBuilder sb) {
+		sb.append(createTableSuffix);
+		sb.append(' ');
+	}
+
+	@Override
+	public boolean isTruncateSupported() {
+		return true;
+	}
+
+	@Override
+	public boolean isCreateIfNotExistsSupported() {
+		return true;
+	}
+
+	@Override
+	public boolean isCreateIndexIfNotExistsSupported() {
+		return false;
+	}
+}

--- a/src/test/java/com/j256/ormlite/db/MariaDbDatabaseTypeTest.java
+++ b/src/test/java/com/j256/ormlite/db/MariaDbDatabaseTypeTest.java
@@ -1,0 +1,98 @@
+package com.j256.ormlite.db;
+
+import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.jdbc.JdbcConnectionSource;
+import com.j256.ormlite.table.TableInfo;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MariaDbDatabaseTypeTest extends BaseJdbcDatabaseTypeTest {
+
+	@Override
+	protected void setDatabaseParams() throws SQLException {
+		databaseUrl = "jdbc:mariadb:ormlite";
+		connectionSource = new JdbcConnectionSource(DEFAULT_DATABASE_URL);
+		databaseType = new MariaDbDatabaseType();
+	}
+
+	@Override
+	protected boolean isDriverClassExpected() {
+		return false;
+	}
+
+	@Test
+	public void testBoolean() throws Exception {
+		if (connectionSource == null) {
+			return;
+		}
+		TableInfo<AllTypes, Integer> tableInfo =
+				new TableInfo<AllTypes, Integer>(connectionSource, null, AllTypes.class);
+		assertEquals(9, tableInfo.getFieldTypes().length);
+		FieldType booleanField = tableInfo.getFieldTypes()[1];
+		assertEquals("booleanField", booleanField.getColumnName());
+		StringBuilder sb = new StringBuilder();
+		List<String> additionalArgs = new ArrayList<String>();
+		List<String> statementsBefore = new ArrayList<String>();
+		databaseType.appendColumnArg(null, sb, booleanField, additionalArgs, statementsBefore, null, null);
+		assertTrue(sb.toString().contains("TINYINT(1)"));
+	}
+
+	@Test
+	public void testGeneratedIdBuilt() throws Exception {
+		if (connectionSource == null) {
+			return;
+		}
+		TableInfo<GeneratedId, Integer> tableInfo =
+				new TableInfo<GeneratedId, Integer>(connectionSource, null, GeneratedId.class);
+		assertEquals(2, tableInfo.getFieldTypes().length);
+		StringBuilder sb = new StringBuilder();
+		List<String> additionalArgs = new ArrayList<String>();
+		List<String> statementsBefore = new ArrayList<String>();
+		databaseType.appendColumnArg(null, sb, tableInfo.getFieldTypes()[0], additionalArgs, statementsBefore, null,
+				null);
+		databaseType.addPrimaryKeySql(tableInfo.getFieldTypes(), additionalArgs, statementsBefore, null, null);
+		assertTrue(sb.toString().contains(" AUTO_INCREMENT"));
+		assertEquals(1, additionalArgs.size());
+		assertTrue(additionalArgs.get(0).contains("PRIMARY KEY"));
+	}
+
+	@Test
+	public void testTableSuffix() {
+		MariaDbDatabaseType dbType = new MariaDbDatabaseType();
+		String suffix = "ewfwefef";
+		dbType.setCreateTableSuffix(suffix);
+		StringBuilder sb = new StringBuilder();
+		dbType.appendCreateTableSuffix(sb);
+		assertTrue(sb.toString().contains(suffix));
+	}
+
+	@Test
+	public void testDateTime() {
+		MariaDbDatabaseType dbType = new MariaDbDatabaseType();
+		StringBuilder sb = new StringBuilder();
+		dbType.appendDateType(sb, null, 0);
+		assertEquals("DATETIME", sb.toString());
+	}
+
+	@Test
+	public void testObject() {
+		MariaDbDatabaseType dbType = new MariaDbDatabaseType();
+		StringBuilder sb = new StringBuilder();
+		dbType.appendByteArrayType(sb, null, 0);
+		assertEquals("BLOB", sb.toString());
+	}
+
+	@Test
+	public void testLongStringSchema() {
+		MariaDbDatabaseType dbType = new MariaDbDatabaseType();
+		StringBuilder sb = new StringBuilder();
+		dbType.appendLongStringType(sb, null, 0);
+		assertEquals("TEXT", sb.toString());
+	}
+}


### PR DESCRIPTION
MariaDB is the community-developed fork of MySQL. It essentially works
as drop-in replacement for MySQL but uses a different JDBC driver,
which thus needs separate support classes (they are pretty much
identical to MySQL's though).
