### PR TITLE
Added UUID as a Specific SQL Type

### DIFF
--- a/src/main/java/com/j256/ormlite/db/PostgresDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/PostgresDatabaseType.java
@@ -29,6 +29,11 @@ public class PostgresDatabaseType extends BaseDatabaseType {
 	}
 
 	@Override
+	protected void appendUUIDType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
+		sb.append("UUID");
+	}
+	
+	@Override
 	protected void appendByteType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
 		sb.append("SMALLINT");
 	}

--- a/src/main/java/com/j256/ormlite/db/SqlServerDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/SqlServerDatabaseType.java
@@ -53,6 +53,11 @@ public class SqlServerDatabaseType extends BaseDatabaseType {
 				return super.getFieldConverter(dataType, fieldType);
 		}
 	}
+	
+	@Override
+	protected void appendUUIDType(StringBuilder sb, FieldType fieldType, int fieldWidth) {
+		sb.append("UNIQUEIDENTIFIER");
+	}
 
 	@Override
 	protected void appendBooleanType(StringBuilder sb, FieldType fieldType, int fieldWidth) {

--- a/src/main/java/com/j256/ormlite/jdbc/TypeValMapper.java
+++ b/src/main/java/com/j256/ormlite/jdbc/TypeValMapper.java
@@ -66,6 +66,8 @@ public class TypeValMapper {
 				case BIG_DECIMAL :
 					values = new int[] { Types.DECIMAL, Types.NUMERIC };
 					break;
+					
+				case UUID:
 				case OTHER :
 					values = new int[] { Types.OTHER };
 					break;


### PR DESCRIPTION
This is intended to use the UUID for PostgreSQL and UNIQUEIDENTIFIER for MSSQL as native sql datatypes. Please see the additional pull request in the core as well.