### PR TITLE
Remove obsolete xerial driver check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.settings
 /.classpath
 /.project
+/.idea
+*.iml

--- a/src/main/java/com/j256/ormlite/db/SqliteDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/SqliteDatabaseType.java
@@ -13,7 +13,6 @@ public class SqliteDatabaseType extends BaseSqliteDatabaseType {
 	private final static String DATABASE_URL_PORTION = "sqlite";
 	private final static String DRIVER_CLASS_NAME = "org.sqlite.JDBC";
 	private final static String DATABASE_NAME = "SQLite";
-	private final static String XERIAL_DRIVER_CLASS = "org.ibex.nestedvm.Interpreter";
 
 	private static final Logger logger = LoggerFactory.getLogger(SqliteDatabaseType.class);
 
@@ -26,13 +25,6 @@ public class SqliteDatabaseType extends BaseSqliteDatabaseType {
 
 	@Override
 	protected String getDriverClassName() {
-		try {
-			// make sure we are using the Xerial driver
-			Class.forName(XERIAL_DRIVER_CLASS);
-		} catch (Exception e) {
-			logger.error("WARNING: you seem to not be using the Xerial SQLite driver.  "
-					+ "See ORMLite docs on SQLite: http://ormlite.com/docs/sqlite");
-		}
 		return DRIVER_CLASS_NAME;
 	}
 


### PR DESCRIPTION
This check doesn't work anymore, cause there is no `org.ibex.nestedvm.Interpreter` class in xerial driver. And since zentus driver seems to be gone, we can remove the check.