### PR TITLE
Update JdbcConnectionSource.java

### DIFF
--- a/src/main/java/com/j256/ormlite/jdbc/JdbcConnectionSource.java
+++ b/src/main/java/com/j256/ormlite/jdbc/JdbcConnectionSource.java
@@ -193,7 +193,7 @@ public class JdbcConnectionSource extends BaseConnectionSource implements Connec
 		if (!initialized) {
 			throw new SQLException(getClass().getSimpleName() + " was not initialized properly");
 		}
-		// noop right now
+		close();
 	}
 
 	@Override


### PR DESCRIPTION
If the connection is not closed in the releaseConnection(DatabaseConnection connection) method, then the number of unused (idle) connections will accumulate over time, and exceed the max. simultaneous connections to the DB. E.g. in case of PostgreSQL this exception will come up soon, if you use the close() method only in the original implementation of this class. "FATAL: connection limit exceeded for non-superusers"