### PR TITLE
Changed DB2 driver class name

### DIFF
--- a/src/main/java/com/j256/ormlite/db/Db2DatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/Db2DatabaseType.java
@@ -19,7 +19,7 @@ public class Db2DatabaseType extends BaseDatabaseType {
 
 	private final static String DATABASE_URL_PORTION = "db2";
 	private final static String DATABASE_NAME = "DB2";
-	private final static String DRIVER_CLASS_NAME = "COM.ibm.db2.jdbc.app.DB2Driver";
+	private final static String DRIVER_CLASS_NAME = "com.ibm.db2.jcc.DB2Driver";
 
 	@Override
 	public boolean isDatabaseUrlThisType(String url, String dbTypePart) {


### PR DESCRIPTION
Please consider using com.ibm.db2.jcc.DB2Driver as DB2 driver class instead of COM.ibm.db2.jdbc.app.DB2Driver.
com.ibm.db2.jcc.DB2Driver is the right class if you plan to use jdbc4 DB2 thin driver