### PR TITLE
Added in Hsqldb 2.3.x EXISTS subquery support

### DIFF
--- a/src/main/java/com/j256/ormlite/db/HsqldbDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/HsqldbDatabaseType.java
@@ -154,4 +154,16 @@ public class HsqldbDatabaseType extends BaseDatabaseType {
 	public String getPingStatement() {
 		return "SELECT COUNT(*) FROM INFORMATION_SCHEMA.SYSTEM_TABLES";
 	}
+
+	@Override
+	public boolean isCreateIfNotExistsSupported() {
+		/**
+		 * Support for EXISTS subquery was added in 2.3.x
+		 */
+		if (driver != null && driver.getMajorVersion() >= 2 && driver.getMinorVersion() >= 3){
+			return true;
+		} else {
+			return false;
+		}
+	}
 }


### PR DESCRIPTION
In HSQLDB 2.3.x support for the EXISTS subquery was added on to tables and columns. I've modified HsqldbDatabaseType.java to reflect this change while maintaining backwards compatibility. 