### PR TITLE
Update SqlServerDatabaseType.appendEscapedEntityName to format entity names correctly

### DIFF
--- a/src/main/java/com/j256/ormlite/db/SqlServerDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/SqlServerDatabaseType.java
@@ -106,10 +106,21 @@ public class SqlServerDatabaseType extends BaseDatabaseType {
 	}
 
 	@Override
-	public void appendEscapedEntityName(StringBuilder sb, String name) {
-		sb.append('\"').append(name).append('\"');
+    public void appendEscapedEntityName(final StringBuilder sb,
+            final String name) {
+        String[] names = name.split("\\.");
+        appendEscapedEntityNamePart(sb, names[0]);
+        for (int i = 1; i < names.length; i++) {
+            sb.append('.');
+            appendEscapedEntityNamePart(sb, names[i]);
+        }
+    }
+	
+	private void appendEscapedEntityNamePart(final StringBuilder sb,
+			final String name) {
+		sb.append('[').append(name).append(']');
 	}
-
+	
 	@Override
 	public boolean isLimitAfterSelect() {
 		return true;

--- a/src/test/java/com/j256/ormlite/db/SqlServerDatabaseTypeTest.java
+++ b/src/test/java/com/j256/ormlite/db/SqlServerDatabaseTypeTest.java
@@ -35,9 +35,18 @@ public class SqlServerDatabaseTypeTest extends BaseJdbcDatabaseTypeTest {
 	@Test
 	public void testEscapedEntityName() {
 		String word = "word";
-		assertEquals("\"" + word + "\"", TestUtils.appendEscapedEntityName(databaseType, word));
+		assertEquals("[" + word + "]", TestUtils.appendEscapedEntityName(databaseType, word));
 	}
 
+	@Test
+	public void testMultipartEscapedEntityName() {
+		String firstPart = "firstPart";
+		String secondPart = "secondPart";
+		String input = firstPart + "." + secondPart;
+		String expected = "[" + firstPart + "].[" + secondPart + "]";
+		assertEquals(expected, TestUtils.appendEscapedEntityName(databaseType, input));
+	}
+	
 	@Override
 	@Test
 	public void testLimitAfterSelect() {


### PR DESCRIPTION
Should result in identifiers formatted according to the following pattern
[database].[schema].[table]