### PR TITLE
Updated driver name

### DIFF
--- a/src/main/java/com/j256/ormlite/db/MysqlDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/MysqlDatabaseType.java
@@ -19,7 +19,7 @@ import com.j256.ormlite.field.FieldType;
 public class MysqlDatabaseType extends BaseDatabaseType {
 
 	private final static String DATABASE_URL_PORTION = "mysql";
-	private final static String DRIVER_CLASS_NAME = "com.mysql.jdbc.Driver";
+	private final static String DRIVER_CLASS_NAME = "com.mysql.cj.jdbc.Driver";
 	private final static String DATABASE_NAME = "MySQL";
 
 	/**


### PR DESCRIPTION
Loading class `com.mysql.jdbc.Driver'. This is deprecated. The new driver class is `com.mysql.cj.jdbc.Driver'. The driver is automatically registered via the SPI and manual loading of the driver class is generally unnecessary.