### PR TITLE
ormite core top package moved

### DIFF
--- a/src/main/java/com/j256/ormlite/db/DatabaseTypeUtils.java
+++ b/src/main/java/com/j256/ormlite/db/DatabaseTypeUtils.java
@@ -1,5 +1,7 @@
 package com.j256.ormlite.db;
 
+import com.j256.ormlite.core.db.DatabaseType;
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/j256/ormlite/db/Db2DatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/Db2DatabaseType.java
@@ -2,7 +2,8 @@ package com.j256.ormlite.db;
 
 import java.util.List;
 
-import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.core.db.BaseDatabaseType;
+import com.j256.ormlite.core.field.FieldType;
 
 /**
  * IBM DB2 database type information used to create the tables, etc..

--- a/src/main/java/com/j256/ormlite/db/DerbyEmbeddedDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/DerbyEmbeddedDatabaseType.java
@@ -9,14 +9,16 @@ import java.util.List;
 
 import javax.sql.rowset.serial.SerialBlob;
 
-import com.j256.ormlite.field.BaseFieldConverter;
-import com.j256.ormlite.field.DataPersister;
-import com.j256.ormlite.field.FieldConverter;
-import com.j256.ormlite.field.FieldType;
-import com.j256.ormlite.field.SqlType;
-import com.j256.ormlite.misc.IOUtils;
-import com.j256.ormlite.misc.SqlExceptionUtil;
-import com.j256.ormlite.support.DatabaseResults;
+import com.j256.ormlite.core.db.BaseDatabaseType;
+import com.j256.ormlite.core.db.BooleanNumberFieldConverter;
+import com.j256.ormlite.core.field.BaseFieldConverter;
+import com.j256.ormlite.core.field.DataPersister;
+import com.j256.ormlite.core.field.FieldConverter;
+import com.j256.ormlite.core.field.FieldType;
+import com.j256.ormlite.core.field.SqlType;
+import com.j256.ormlite.core.misc.IOUtils;
+import com.j256.ormlite.core.misc.SqlExceptionUtil;
+import com.j256.ormlite.core.support.DatabaseResults;
 
 /**
  * Derby database type information used to create the tables, etc.. This is for an embedded Derby database. For client

--- a/src/main/java/com/j256/ormlite/db/GenericOdbcDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/GenericOdbcDatabaseType.java
@@ -1,5 +1,7 @@
 package com.j256.ormlite.db;
 
+import com.j256.ormlite.core.db.BaseDatabaseType;
+
 /**
  * Generic JdbcOdbcBridge database type information used to create the tables, etc..
  * 

--- a/src/main/java/com/j256/ormlite/db/H2DatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/H2DatabaseType.java
@@ -2,7 +2,8 @@ package com.j256.ormlite.db;
 
 import java.util.List;
 
-import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.core.db.BaseDatabaseType;
+import com.j256.ormlite.core.field.FieldType;
 
 /**
  * H2 database type information used to create the tables, etc..

--- a/src/main/java/com/j256/ormlite/db/HsqldbDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/HsqldbDatabaseType.java
@@ -2,8 +2,9 @@ package com.j256.ormlite.db;
 
 import java.util.List;
 
-import com.j256.ormlite.field.FieldType;
-import com.j256.ormlite.field.SqlType;
+import com.j256.ormlite.core.db.BaseDatabaseType;
+import com.j256.ormlite.core.field.FieldType;
+import com.j256.ormlite.core.field.SqlType;
 
 /**
  * HyberSQL database type information used to create the tables, etc..

--- a/src/main/java/com/j256/ormlite/db/MysqlDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/MysqlDatabaseType.java
@@ -2,7 +2,8 @@ package com.j256.ormlite.db;
 
 import java.util.List;
 
-import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.core.db.BaseDatabaseType;
+import com.j256.ormlite.core.field.FieldType;
 
 /**
  * MySQL database type information used to create the tables, etc..

--- a/src/main/java/com/j256/ormlite/db/NetezzaDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/NetezzaDatabaseType.java
@@ -2,7 +2,8 @@ package com.j256.ormlite.db;
 
 import java.util.List;
 
-import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.core.db.BaseDatabaseType;
+import com.j256.ormlite.core.field.FieldType;
 
 /**
  * Netezza database type information used to create the tables, etc..

--- a/src/main/java/com/j256/ormlite/db/OracleDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/OracleDatabaseType.java
@@ -2,10 +2,11 @@ package com.j256.ormlite.db;
 
 import java.util.List;
 
-import com.j256.ormlite.field.DataPersister;
-import com.j256.ormlite.field.DataType;
-import com.j256.ormlite.field.FieldConverter;
-import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.core.db.BaseDatabaseType;
+import com.j256.ormlite.core.field.DataPersister;
+import com.j256.ormlite.core.field.DataType;
+import com.j256.ormlite.core.field.FieldConverter;
+import com.j256.ormlite.core.field.FieldType;
 
 /**
  * Oracle database type information used to create the tables, etc..

--- a/src/main/java/com/j256/ormlite/db/PostgresDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/PostgresDatabaseType.java
@@ -2,7 +2,8 @@ package com.j256.ormlite.db;
 
 import java.util.List;
 
-import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.core.db.BaseDatabaseType;
+import com.j256.ormlite.core.field.FieldType;
 
 /**
  * Postgres database type information used to create the tables, etc..

--- a/src/main/java/com/j256/ormlite/db/SqlServerDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/SqlServerDatabaseType.java
@@ -3,12 +3,14 @@ package com.j256.ormlite.db;
 import java.sql.SQLException;
 import java.util.List;
 
-import com.j256.ormlite.field.BaseFieldConverter;
-import com.j256.ormlite.field.DataPersister;
-import com.j256.ormlite.field.FieldConverter;
-import com.j256.ormlite.field.FieldType;
-import com.j256.ormlite.field.SqlType;
-import com.j256.ormlite.support.DatabaseResults;
+import com.j256.ormlite.core.db.BaseDatabaseType;
+import com.j256.ormlite.core.db.BooleanNumberFieldConverter;
+import com.j256.ormlite.core.field.BaseFieldConverter;
+import com.j256.ormlite.core.field.DataPersister;
+import com.j256.ormlite.core.field.FieldConverter;
+import com.j256.ormlite.core.field.FieldType;
+import com.j256.ormlite.core.field.SqlType;
+import com.j256.ormlite.core.support.DatabaseResults;
 
 /**
  * Microsoft SQL server database type information used to create the tables, etc..

--- a/src/main/java/com/j256/ormlite/db/SqliteDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/SqliteDatabaseType.java
@@ -1,5 +1,7 @@
 package com.j256.ormlite.db;
 
+import com.j256.ormlite.core.db.BaseSqliteDatabaseType;
+
 /**
  * Sqlite database type information used to create the tables, etc..
  * 

--- a/src/main/java/com/j256/ormlite/jdbc/DataSourceConnectionSource.java
+++ b/src/main/java/com/j256/ormlite/jdbc/DataSourceConnectionSource.java
@@ -7,14 +7,14 @@ import java.sql.SQLException;
 
 import javax.sql.DataSource;
 
-import com.j256.ormlite.db.DatabaseType;
+import com.j256.ormlite.core.db.DatabaseType;
 import com.j256.ormlite.db.DatabaseTypeUtils;
-import com.j256.ormlite.logger.Logger;
-import com.j256.ormlite.logger.LoggerFactory;
-import com.j256.ormlite.misc.IOUtils;
-import com.j256.ormlite.support.BaseConnectionSource;
-import com.j256.ormlite.support.ConnectionSource;
-import com.j256.ormlite.support.DatabaseConnection;
+import com.j256.ormlite.core.logger.Logger;
+import com.j256.ormlite.core.logger.LoggerFactory;
+import com.j256.ormlite.core.misc.IOUtils;
+import com.j256.ormlite.core.support.BaseConnectionSource;
+import com.j256.ormlite.core.support.ConnectionSource;
+import com.j256.ormlite.core.support.DatabaseConnection;
 
 /**
  * Wrapper around a {@link DataSource} that supports our ConnectionSource interface. This allows you to wrap other

--- a/src/main/java/com/j256/ormlite/jdbc/JdbcCompiledStatement.java
+++ b/src/main/java/com/j256/ormlite/jdbc/JdbcCompiledStatement.java
@@ -5,12 +5,12 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 
-import com.j256.ormlite.dao.ObjectCache;
-import com.j256.ormlite.field.SqlType;
-import com.j256.ormlite.misc.IOUtils;
-import com.j256.ormlite.stmt.StatementBuilder.StatementType;
-import com.j256.ormlite.support.CompiledStatement;
-import com.j256.ormlite.support.DatabaseResults;
+import com.j256.ormlite.core.dao.ObjectCache;
+import com.j256.ormlite.core.field.SqlType;
+import com.j256.ormlite.core.misc.IOUtils;
+import com.j256.ormlite.core.stmt.StatementBuilder.StatementType;
+import com.j256.ormlite.core.support.CompiledStatement;
+import com.j256.ormlite.core.support.DatabaseResults;
 
 /**
  * Wrapper around a {@link PreparedStatement} object which we delegate to.

--- a/src/main/java/com/j256/ormlite/jdbc/JdbcConnectionSource.java
+++ b/src/main/java/com/j256/ormlite/jdbc/JdbcConnectionSource.java
@@ -5,15 +5,15 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
 
-import com.j256.ormlite.db.DatabaseType;
+import com.j256.ormlite.core.db.DatabaseType;
 import com.j256.ormlite.db.DatabaseTypeUtils;
-import com.j256.ormlite.logger.Logger;
-import com.j256.ormlite.logger.LoggerFactory;
-import com.j256.ormlite.misc.IOUtils;
-import com.j256.ormlite.support.BaseConnectionSource;
-import com.j256.ormlite.support.ConnectionSource;
-import com.j256.ormlite.support.DatabaseConnection;
-import com.j256.ormlite.support.DatabaseConnectionProxyFactory;
+import com.j256.ormlite.core.logger.Logger;
+import com.j256.ormlite.core.logger.LoggerFactory;
+import com.j256.ormlite.core.misc.IOUtils;
+import com.j256.ormlite.core.support.BaseConnectionSource;
+import com.j256.ormlite.core.support.ConnectionSource;
+import com.j256.ormlite.core.support.DatabaseConnection;
+import com.j256.ormlite.core.support.DatabaseConnectionProxyFactory;
 
 /**
  * Implementation of the ConnectionSource interface that supports what is needed by ORMLite. This is not thread-safe nor

--- a/src/main/java/com/j256/ormlite/jdbc/JdbcDatabaseConnection.java
+++ b/src/main/java/com/j256/ormlite/jdbc/JdbcDatabaseConnection.java
@@ -11,18 +11,18 @@ import java.sql.Savepoint;
 import java.sql.Statement;
 import java.sql.Types;
 
-import com.j256.ormlite.dao.ObjectCache;
-import com.j256.ormlite.field.FieldType;
-import com.j256.ormlite.logger.Logger;
-import com.j256.ormlite.logger.LoggerFactory;
-import com.j256.ormlite.misc.IOUtils;
-import com.j256.ormlite.misc.VersionUtils;
-import com.j256.ormlite.stmt.GenericRowMapper;
-import com.j256.ormlite.stmt.StatementBuilder.StatementType;
-import com.j256.ormlite.support.CompiledStatement;
-import com.j256.ormlite.support.DatabaseConnection;
-import com.j256.ormlite.support.DatabaseResults;
-import com.j256.ormlite.support.GeneratedKeyHolder;
+import com.j256.ormlite.core.dao.ObjectCache;
+import com.j256.ormlite.core.field.FieldType;
+import com.j256.ormlite.core.logger.Logger;
+import com.j256.ormlite.core.logger.LoggerFactory;
+import com.j256.ormlite.core.misc.IOUtils;
+import com.j256.ormlite.core.misc.VersionUtils;
+import com.j256.ormlite.core.stmt.GenericRowMapper;
+import com.j256.ormlite.core.stmt.StatementBuilder.StatementType;
+import com.j256.ormlite.core.support.CompiledStatement;
+import com.j256.ormlite.core.support.DatabaseConnection;
+import com.j256.ormlite.core.support.DatabaseResults;
+import com.j256.ormlite.core.support.GeneratedKeyHolder;
 
 /**
  * Wrapper around a JDBC {@link Connection} object which we delegate to.
@@ -31,7 +31,7 @@ import com.j256.ormlite.support.GeneratedKeyHolder;
  */
 public class JdbcDatabaseConnection implements DatabaseConnection {
 
-	private static final String JDBC_VERSION = "VERSION__5.1-SNAPSHOT__";
+	private static final String JDBC_VERSION = "VERSION__5.2-SNAPSHOT__";
 
 	private static Logger logger = LoggerFactory.getLogger(JdbcDatabaseConnection.class);
 	private static final String JDBC_META_TABLE_NAME_COLUMN = "TABLE_NAME";

--- a/src/main/java/com/j256/ormlite/jdbc/JdbcDatabaseResults.java
+++ b/src/main/java/com/j256/ormlite/jdbc/JdbcDatabaseResults.java
@@ -10,9 +10,9 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 
-import com.j256.ormlite.dao.ObjectCache;
-import com.j256.ormlite.misc.IOUtils;
-import com.j256.ormlite.support.DatabaseResults;
+import com.j256.ormlite.core.dao.ObjectCache;
+import com.j256.ormlite.core.misc.IOUtils;
+import com.j256.ormlite.core.support.DatabaseResults;
 
 /**
  * Wrapper around a {@link ResultSet} object which we delegate to.

--- a/src/main/java/com/j256/ormlite/jdbc/JdbcPooledConnectionSource.java
+++ b/src/main/java/com/j256/ormlite/jdbc/JdbcPooledConnectionSource.java
@@ -9,13 +9,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.j256.ormlite.db.DatabaseType;
-import com.j256.ormlite.logger.Log.Level;
-import com.j256.ormlite.logger.Logger;
-import com.j256.ormlite.logger.LoggerFactory;
-import com.j256.ormlite.misc.IOUtils;
-import com.j256.ormlite.support.ConnectionSource;
-import com.j256.ormlite.support.DatabaseConnection;
+import com.j256.ormlite.core.db.DatabaseType;
+import com.j256.ormlite.core.logger.Log.Level;
+import com.j256.ormlite.core.logger.Logger;
+import com.j256.ormlite.core.logger.LoggerFactory;
+import com.j256.ormlite.core.misc.IOUtils;
+import com.j256.ormlite.core.support.ConnectionSource;
+import com.j256.ormlite.core.support.DatabaseConnection;
 
 /**
  * Implementation of the ConnectionSource interface that supports basic pooled connections. New connections are created

--- a/src/main/java/com/j256/ormlite/jdbc/JdbcSingleConnectionSource.java
+++ b/src/main/java/com/j256/ormlite/jdbc/JdbcSingleConnectionSource.java
@@ -3,9 +3,9 @@ package com.j256.ormlite.jdbc;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import com.j256.ormlite.db.DatabaseType;
-import com.j256.ormlite.support.ConnectionSource;
-import com.j256.ormlite.support.DatabaseConnection;
+import com.j256.ormlite.core.db.DatabaseType;
+import com.j256.ormlite.core.support.ConnectionSource;
+import com.j256.ormlite.core.support.DatabaseConnection;
 
 /**
  * A connection sounds that uses an existing open database connection. This is not thread-safe nor synchronized. For

--- a/src/main/java/com/j256/ormlite/jdbc/TypeValMapper.java
+++ b/src/main/java/com/j256/ormlite/jdbc/TypeValMapper.java
@@ -5,7 +5,7 @@ import java.sql.Types;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.j256.ormlite.field.SqlType;
+import com.j256.ormlite.core.field.SqlType;
 
 /**
  * Map from {@link SqlType} to the constants in the {@link Types} class.

--- a/src/main/java/com/j256/ormlite/logger/Log4j2Log.java
+++ b/src/main/java/com/j256/ormlite/logger/Log4j2Log.java
@@ -1,7 +1,9 @@
 package com.j256.ormlite.logger;
 
+import com.j256.ormlite.core.logger.Log;
+
 /**
- * Class which implements our {@link com.j256.ormlite.logger.Log} interface by delegating to Apache Log4j2.
+ * Class which implements our {@link com.j256.ormlite.core.logger.Log} interface by delegating to Apache Log4j2.
  * 
  * @author graywatson
  */

--- a/src/main/java/com/j256/ormlite/logger/Log4jLog.java
+++ b/src/main/java/com/j256/ormlite/logger/Log4jLog.java
@@ -1,8 +1,10 @@
 package com.j256.ormlite.logger;
 
+import com.j256.ormlite.core.logger.Log;
+
 /**
- * Class which implements our {@link com.j256.ormlite.logger.Log} interface by delegating to Apache Log4j.
- * 
+ * Class which implements our {@link com.j256.ormlite.core.logger.Log} interface by delegating to Apache Log4j.
+ *
  * @author graywatson
  */
 public class Log4jLog implements Log {
@@ -28,7 +30,7 @@ public class Log4jLog implements Log {
 		logger.log(levelToLog4jLevel(level), msg, t);
 	}
 
-	private org.apache.log4j.Level levelToLog4jLevel(com.j256.ormlite.logger.Log.Level level) {
+	private org.apache.log4j.Level levelToLog4jLevel(com.j256.ormlite.core.logger.Log.Level level) {
 		switch (level) {
 			case TRACE:
 				return org.apache.log4j.Level.TRACE;

--- a/src/main/java/com/j256/ormlite/spring/DaoFactory.java
+++ b/src/main/java/com/j256/ormlite/spring/DaoFactory.java
@@ -2,10 +2,10 @@ package com.j256.ormlite.spring;
 
 import java.sql.SQLException;
 
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.dao.DaoManager;
-import com.j256.ormlite.support.ConnectionSource;
-import com.j256.ormlite.table.DatabaseTableConfig;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.dao.DaoManager;
+import com.j256.ormlite.core.support.ConnectionSource;
+import com.j256.ormlite.core.table.DatabaseTableConfig;
 
 /**
  * <p>

--- a/src/main/java/com/j256/ormlite/spring/TableCreator.java
+++ b/src/main/java/com/j256/ormlite/spring/TableCreator.java
@@ -5,11 +5,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.j256.ormlite.dao.BaseDaoImpl;
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.support.ConnectionSource;
-import com.j256.ormlite.table.DatabaseTableConfig;
-import com.j256.ormlite.table.TableUtils;
+import com.j256.ormlite.core.dao.BaseDaoImpl;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.support.ConnectionSource;
+import com.j256.ormlite.core.table.DatabaseTableConfig;
+import com.j256.ormlite.core.table.TableUtils;
 
 /**
  * Spring bean that auto-creates any tables that it finds DAOs for if the property name in

--- a/src/test/java/com/j256/ormlite/BaseJdbcTest.java
+++ b/src/test/java/com/j256/ormlite/BaseJdbcTest.java
@@ -22,13 +22,13 @@ import org.junit.rules.MethodRule;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 
-import com.j256.ormlite.dao.BaseDaoImpl;
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.dao.DaoManager;
-import com.j256.ormlite.db.DatabaseType;
+import com.j256.ormlite.core.dao.BaseDaoImpl;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.dao.DaoManager;
+import com.j256.ormlite.core.db.DatabaseType;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.table.DatabaseTableConfig;
-import com.j256.ormlite.table.TableUtils;
+import com.j256.ormlite.core.table.DatabaseTableConfig;
+import com.j256.ormlite.core.table.TableUtils;
 
 public abstract class BaseJdbcTest {
 

--- a/src/test/java/com/j256/ormlite/WrappedJdbcConnectionSource.java
+++ b/src/test/java/com/j256/ormlite/WrappedJdbcConnectionSource.java
@@ -9,9 +9,11 @@ import java.sql.PreparedStatement;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.j256.ormlite.core.WrappedConnection;
+import com.j256.ormlite.core.WrappedConnectionSource;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
 import com.j256.ormlite.jdbc.JdbcDatabaseConnection;
-import com.j256.ormlite.support.DatabaseConnection;
+import com.j256.ormlite.core.support.DatabaseConnection;
 
 /**
  * Wrapped connection source for JDBC testing purposes.

--- a/src/test/java/com/j256/ormlite/dao/BulkJdbcDaoTest.java
+++ b/src/test/java/com/j256/ormlite/dao/BulkJdbcDaoTest.java
@@ -4,11 +4,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.j256.ormlite.core.dao.Dao;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.j256.ormlite.BaseJdbcTest;
-import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.core.field.DatabaseField;
 
 public class BulkJdbcDaoTest extends BaseJdbcTest {
 

--- a/src/test/java/com/j256/ormlite/dao/DoubleDbOpenTest.java
+++ b/src/test/java/com/j256/ormlite/dao/DoubleDbOpenTest.java
@@ -5,14 +5,16 @@ import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.dao.DaoManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.j256.ormlite.BaseCoreTest;
+import com.j256.ormlite.core.BaseCoreTest;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.support.ConnectionSource;
-import com.j256.ormlite.table.TableUtils;
+import com.j256.ormlite.core.support.ConnectionSource;
+import com.j256.ormlite.core.table.TableUtils;
 
 public class DoubleDbOpenTest extends BaseCoreTest {
 

--- a/src/test/java/com/j256/ormlite/dao/JdbcBaseDaoImplTest.java
+++ b/src/test/java/com/j256/ormlite/dao/JdbcBaseDaoImplTest.java
@@ -29,25 +29,31 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 
+import com.j256.ormlite.core.dao.BaseDaoImpl;
+import com.j256.ormlite.core.dao.CloseableIterator;
+import com.j256.ormlite.core.dao.DaoManager;
+import com.j256.ormlite.core.dao.GenericRawResults;
+import com.j256.ormlite.core.dao.RawRowMapper;
 import org.junit.Test;
 
 import com.j256.ormlite.BaseJdbcTest;
-import com.j256.ormlite.dao.Dao.CreateOrUpdateStatus;
-import com.j256.ormlite.field.DataType;
-import com.j256.ormlite.field.DatabaseField;
-import com.j256.ormlite.field.DatabaseFieldConfig;
-import com.j256.ormlite.field.ForeignCollectionField;
-import com.j256.ormlite.misc.BaseDaoEnabled;
-import com.j256.ormlite.stmt.DeleteBuilder;
-import com.j256.ormlite.stmt.PreparedQuery;
-import com.j256.ormlite.stmt.QueryBuilder;
-import com.j256.ormlite.stmt.SelectArg;
-import com.j256.ormlite.stmt.UpdateBuilder;
-import com.j256.ormlite.stmt.Where;
-import com.j256.ormlite.support.DatabaseConnection;
-import com.j256.ormlite.table.DatabaseTable;
-import com.j256.ormlite.table.DatabaseTableConfig;
-import com.j256.ormlite.table.TableUtils;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.dao.Dao.CreateOrUpdateStatus;
+import com.j256.ormlite.core.field.DataType;
+import com.j256.ormlite.core.field.DatabaseField;
+import com.j256.ormlite.core.field.DatabaseFieldConfig;
+import com.j256.ormlite.core.field.ForeignCollectionField;
+import com.j256.ormlite.core.misc.BaseDaoEnabled;
+import com.j256.ormlite.core.stmt.DeleteBuilder;
+import com.j256.ormlite.core.stmt.PreparedQuery;
+import com.j256.ormlite.core.stmt.QueryBuilder;
+import com.j256.ormlite.core.stmt.SelectArg;
+import com.j256.ormlite.core.stmt.UpdateBuilder;
+import com.j256.ormlite.core.stmt.Where;
+import com.j256.ormlite.core.support.DatabaseConnection;
+import com.j256.ormlite.core.table.DatabaseTable;
+import com.j256.ormlite.core.table.DatabaseTableConfig;
+import com.j256.ormlite.core.table.TableUtils;
 
 public class JdbcBaseDaoImplTest extends BaseJdbcTest {
 
@@ -1617,7 +1623,7 @@ public class JdbcBaseDaoImplTest extends BaseJdbcTest {
 
 		String queryString = buildFooQueryAllString(fooDao);
 		Mapper mapper = new Mapper();
-		GenericRawResults<Foo> rawResults = fooDao.queryRaw(queryString, mapper);
+		GenericRawResults<Foo> rawResults = fooDao.queryRaw(queryString, mapper, null);
 		assertEquals(0, rawResults.getResults().size());
 		assertEquals(1, fooDao.create(foo));
 		rawResults = fooDao.queryRaw(queryString, mapper);

--- a/src/test/java/com/j256/ormlite/dao/JdbcBaseDaoImplTest.java
+++ b/src/test/java/com/j256/ormlite/dao/JdbcBaseDaoImplTest.java
@@ -1623,7 +1623,7 @@ public class JdbcBaseDaoImplTest extends BaseJdbcTest {
 
 		String queryString = buildFooQueryAllString(fooDao);
 		Mapper mapper = new Mapper();
-		GenericRawResults<Foo> rawResults = fooDao.queryRaw(queryString, mapper, null);
+		GenericRawResults<Foo> rawResults = fooDao.queryRaw(queryString, mapper, new String[]{});
 		assertEquals(0, rawResults.getResults().size());
 		assertEquals(1, fooDao.create(foo));
 		rawResults = fooDao.queryRaw(queryString, mapper);

--- a/src/test/java/com/j256/ormlite/db/BaseJdbcDatabaseTypeTest.java
+++ b/src/test/java/com/j256/ormlite/db/BaseJdbcDatabaseTypeTest.java
@@ -13,13 +13,13 @@ import java.util.List;
 import org.junit.Test;
 
 import com.j256.ormlite.BaseJdbcTest;
-import com.j256.ormlite.TestUtils;
-import com.j256.ormlite.field.DatabaseField;
-import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.core.TestUtils;
+import com.j256.ormlite.core.field.DatabaseField;
+import com.j256.ormlite.core.field.FieldType;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.stmt.QueryBuilder;
-import com.j256.ormlite.support.DatabaseConnection;
-import com.j256.ormlite.table.TableInfo;
+import com.j256.ormlite.core.stmt.QueryBuilder;
+import com.j256.ormlite.core.support.DatabaseConnection;
+import com.j256.ormlite.core.table.TableInfo;
 
 /**
  * Base test for other database tests which perform specific functionality tests on all databases.

--- a/src/test/java/com/j256/ormlite/db/DatabaseTypeUtilsTest.java
+++ b/src/test/java/com/j256/ormlite/db/DatabaseTypeUtilsTest.java
@@ -7,7 +7,7 @@ import java.lang.reflect.Constructor;
 import org.junit.Test;
 
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.support.ConnectionSource;
+import com.j256.ormlite.core.support.ConnectionSource;
 
 public class DatabaseTypeUtilsTest {
 

--- a/src/test/java/com/j256/ormlite/db/Db2DatabaseTypeTest.java
+++ b/src/test/java/com/j256/ormlite/db/Db2DatabaseTypeTest.java
@@ -10,10 +10,10 @@ import java.util.List;
 
 import org.junit.Test;
 
-import com.j256.ormlite.TestUtils;
-import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.core.TestUtils;
+import com.j256.ormlite.core.field.FieldType;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.table.TableInfo;
+import com.j256.ormlite.core.table.TableInfo;
 
 public class Db2DatabaseTypeTest extends BaseJdbcDatabaseTypeTest {
 

--- a/src/test/java/com/j256/ormlite/db/DerbyEmbeddedDatabaseTypeTest.java
+++ b/src/test/java/com/j256/ormlite/db/DerbyEmbeddedDatabaseTypeTest.java
@@ -17,14 +17,14 @@ import javax.sql.rowset.serial.SerialBlob;
 
 import org.junit.Test;
 
-import com.j256.ormlite.TestUtils;
-import com.j256.ormlite.field.DataType;
-import com.j256.ormlite.field.FieldConverter;
-import com.j256.ormlite.field.FieldType;
-import com.j256.ormlite.field.SqlType;
+import com.j256.ormlite.core.TestUtils;
+import com.j256.ormlite.core.field.DataType;
+import com.j256.ormlite.core.field.FieldConverter;
+import com.j256.ormlite.core.field.FieldType;
+import com.j256.ormlite.core.field.SqlType;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.support.DatabaseResults;
-import com.j256.ormlite.table.TableInfo;
+import com.j256.ormlite.core.support.DatabaseResults;
+import com.j256.ormlite.core.table.TableInfo;
 
 public class DerbyEmbeddedDatabaseTypeTest extends BaseJdbcDatabaseTypeTest {
 

--- a/src/test/java/com/j256/ormlite/db/DerbyEmbeddedDatabaseTypeTest.java
+++ b/src/test/java/com/j256/ormlite/db/DerbyEmbeddedDatabaseTypeTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
+import java.lang.reflect.Method;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -156,10 +157,15 @@ public class DerbyEmbeddedDatabaseTypeTest extends BaseJdbcDatabaseTypeTest {
 	}
 
 	@Test
-	public void testAppendObjectType() {
+	public void testAppendObjectType() throws Exception {
 		StringBuilder sb = new StringBuilder();
 		DerbyEmbeddedDatabaseType type = new DerbyEmbeddedDatabaseType();
-		type.appendSerializableType(sb, null, 0);
+		final Method m = DerbyEmbeddedDatabaseType
+				.class
+				.getSuperclass()
+				.getDeclaredMethod("appendSerializableType", StringBuilder.class, FieldType.class, int.class);
+		m.setAccessible(true);
+		m.invoke(type, sb, null, 0);
 		assertEquals("BLOB", sb.toString());
 	}
 

--- a/src/test/java/com/j256/ormlite/db/H2DatabaseTypeTest.java
+++ b/src/test/java/com/j256/ormlite/db/H2DatabaseTypeTest.java
@@ -8,10 +8,10 @@ import java.util.ArrayList;
 
 import org.junit.Test;
 
-import com.j256.ormlite.TestUtils;
+import com.j256.ormlite.core.TestUtils;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.support.DatabaseConnection;
-import com.j256.ormlite.table.TableInfo;
+import com.j256.ormlite.core.support.DatabaseConnection;
+import com.j256.ormlite.core.table.TableInfo;
 
 public class H2DatabaseTypeTest extends BaseJdbcDatabaseTypeTest {
 

--- a/src/test/java/com/j256/ormlite/db/HsqldbDatabaseTypeTest.java
+++ b/src/test/java/com/j256/ormlite/db/HsqldbDatabaseTypeTest.java
@@ -14,16 +14,17 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.j256.ormlite.core.db.DatabaseType;
 import org.junit.Test;
 
-import com.j256.ormlite.TestUtils;
-import com.j256.ormlite.dao.BaseDaoImpl;
-import com.j256.ormlite.field.DataPersister;
-import com.j256.ormlite.field.DatabaseField;
-import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.core.TestUtils;
+import com.j256.ormlite.core.dao.BaseDaoImpl;
+import com.j256.ormlite.core.field.DataPersister;
+import com.j256.ormlite.core.field.DatabaseField;
+import com.j256.ormlite.core.field.FieldType;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.stmt.QueryBuilder;
-import com.j256.ormlite.table.TableInfo;
+import com.j256.ormlite.core.stmt.QueryBuilder;
+import com.j256.ormlite.core.table.TableInfo;
 
 public class HsqldbDatabaseTypeTest extends BaseJdbcDatabaseTypeTest {
 

--- a/src/test/java/com/j256/ormlite/db/MariaDbDatabaseTypeTest.java
+++ b/src/test/java/com/j256/ormlite/db/MariaDbDatabaseTypeTest.java
@@ -3,6 +3,7 @@ package com.j256.ormlite.db;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Method;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -82,18 +83,30 @@ public class MariaDbDatabaseTypeTest extends BaseJdbcDatabaseTypeTest {
 	}
 
 	@Test
-	public void testObject() {
+	public void testObject() throws Exception {
 		MariaDbDatabaseType dbType = new MariaDbDatabaseType();
 		StringBuilder sb = new StringBuilder();
-		dbType.appendByteArrayType(sb, null, 0);
+		final Method m = MariaDbDatabaseType
+				.class
+				.getSuperclass()
+				.getSuperclass()
+				.getDeclaredMethod("appendByteArrayType", StringBuilder.class, FieldType.class, int.class);
+		m.setAccessible(true);
+		m.invoke(dbType, sb, null, 0);
 		assertEquals("BLOB", sb.toString());
 	}
 
 	@Test
-	public void testLongStringSchema() {
+	public void testLongStringSchema() throws Exception {
 		MariaDbDatabaseType dbType = new MariaDbDatabaseType();
 		StringBuilder sb = new StringBuilder();
-		dbType.appendLongStringType(sb, null, 0);
+		final Method m = MariaDbDatabaseType
+				.class
+				.getSuperclass()
+				.getSuperclass()
+				.getDeclaredMethod("appendLongStringType", StringBuilder.class, FieldType.class, int.class);
+		m.setAccessible(true);
+		m.invoke(dbType, sb, null, 0);
 		assertEquals("TEXT", sb.toString());
 	}
 }

--- a/src/test/java/com/j256/ormlite/db/MariaDbDatabaseTypeTest.java
+++ b/src/test/java/com/j256/ormlite/db/MariaDbDatabaseTypeTest.java
@@ -9,9 +9,9 @@ import java.util.List;
 
 import org.junit.Test;
 
-import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.core.field.FieldType;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.table.TableInfo;
+import com.j256.ormlite.core.table.TableInfo;
 
 public class MariaDbDatabaseTypeTest extends BaseJdbcDatabaseTypeTest {
 

--- a/src/test/java/com/j256/ormlite/db/MysqlDatabaseTypeTest.java
+++ b/src/test/java/com/j256/ormlite/db/MysqlDatabaseTypeTest.java
@@ -9,9 +9,9 @@ import java.util.List;
 
 import org.junit.Test;
 
-import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.core.field.FieldType;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.table.TableInfo;
+import com.j256.ormlite.core.table.TableInfo;
 
 public class MysqlDatabaseTypeTest extends BaseJdbcDatabaseTypeTest {
 

--- a/src/test/java/com/j256/ormlite/db/MysqlDatabaseTypeTest.java
+++ b/src/test/java/com/j256/ormlite/db/MysqlDatabaseTypeTest.java
@@ -3,6 +3,7 @@ package com.j256.ormlite.db;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Method;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -82,18 +83,28 @@ public class MysqlDatabaseTypeTest extends BaseJdbcDatabaseTypeTest {
 	}
 
 	@Test
-	public void testObject() {
+	public void testObject() throws Exception {
 		MysqlDatabaseType dbType = new MysqlDatabaseType();
 		StringBuilder sb = new StringBuilder();
-		dbType.appendByteArrayType(sb, null, 0);
+		final Method m = MysqlDatabaseType
+				.class
+				.getSuperclass()
+				.getDeclaredMethod("appendByteArrayType", StringBuilder.class, FieldType.class, int.class);
+		m.setAccessible(true);
+		m.invoke(dbType, sb, null, 0);
 		assertEquals("BLOB", sb.toString());
 	}
 
 	@Test
-	public void testLongStringSchema() {
+	public void testLongStringSchema() throws Exception {
 		MysqlDatabaseType dbType = new MysqlDatabaseType();
 		StringBuilder sb = new StringBuilder();
-		dbType.appendLongStringType(sb, null, 0);
+		final Method m = MysqlDatabaseType
+				.class
+				.getSuperclass()
+				.getDeclaredMethod("appendLongStringType", StringBuilder.class, FieldType.class, int.class);
+		m.setAccessible(true);
+		m.invoke(dbType, sb, null, 0);
 		assertEquals("TEXT", sb.toString());
 	}
 }

--- a/src/test/java/com/j256/ormlite/db/OracleDatabaseTypeTest.java
+++ b/src/test/java/com/j256/ormlite/db/OracleDatabaseTypeTest.java
@@ -14,13 +14,14 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.j256.ormlite.core.db.DatabaseType;
 import org.junit.Test;
 
-import com.j256.ormlite.TestUtils;
-import com.j256.ormlite.field.DataPersister;
-import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.core.TestUtils;
+import com.j256.ormlite.core.field.DataPersister;
+import com.j256.ormlite.core.field.FieldType;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.table.TableInfo;
+import com.j256.ormlite.core.table.TableInfo;
 
 public class OracleDatabaseTypeTest extends BaseJdbcDatabaseTypeTest {
 

--- a/src/test/java/com/j256/ormlite/db/PostgresDatabaseTypeTest.java
+++ b/src/test/java/com/j256/ormlite/db/PostgresDatabaseTypeTest.java
@@ -13,13 +13,14 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.j256.ormlite.core.db.DatabaseType;
 import org.junit.Test;
 
-import com.j256.ormlite.TestUtils;
-import com.j256.ormlite.field.DataPersister;
-import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.core.TestUtils;
+import com.j256.ormlite.core.field.DataPersister;
+import com.j256.ormlite.core.field.FieldType;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.table.TableInfo;
+import com.j256.ormlite.core.table.TableInfo;
 
 public class PostgresDatabaseTypeTest extends BaseJdbcDatabaseTypeTest {
 

--- a/src/test/java/com/j256/ormlite/db/SqlServerDatabaseTypeTest.java
+++ b/src/test/java/com/j256/ormlite/db/SqlServerDatabaseTypeTest.java
@@ -10,12 +10,12 @@ import java.util.List;
 
 import org.junit.Test;
 
-import com.j256.ormlite.TestUtils;
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.core.TestUtils;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.field.FieldType;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.stmt.QueryBuilder;
-import com.j256.ormlite.table.TableInfo;
+import com.j256.ormlite.core.stmt.QueryBuilder;
+import com.j256.ormlite.core.table.TableInfo;
 
 public class SqlServerDatabaseTypeTest extends BaseJdbcDatabaseTypeTest {
 

--- a/src/test/java/com/j256/ormlite/db/SqliteDatabaseTypeTest.java
+++ b/src/test/java/com/j256/ormlite/db/SqliteDatabaseTypeTest.java
@@ -12,13 +12,13 @@ import java.util.List;
 
 import org.junit.Test;
 
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.dao.GenericRawResults;
-import com.j256.ormlite.field.DataType;
-import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.dao.GenericRawResults;
+import com.j256.ormlite.core.field.DataType;
+import com.j256.ormlite.core.field.DatabaseField;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.stmt.QueryBuilder;
-import com.j256.ormlite.table.TableInfo;
+import com.j256.ormlite.core.stmt.QueryBuilder;
+import com.j256.ormlite.core.table.TableInfo;
 
 public class SqliteDatabaseTypeTest extends BaseJdbcDatabaseTypeTest {
 

--- a/src/test/java/com/j256/ormlite/examples/datapersister/DataPersisterMain.java
+++ b/src/test/java/com/j256/ormlite/examples/datapersister/DataPersisterMain.java
@@ -7,13 +7,13 @@ import java.util.Date;
 
 import org.joda.time.DateTime;
 
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.dao.DaoManager;
-import com.j256.ormlite.field.DataPersisterManager;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.dao.DaoManager;
+import com.j256.ormlite.core.field.DataPersisterManager;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.stmt.UpdateBuilder;
-import com.j256.ormlite.support.ConnectionSource;
-import com.j256.ormlite.table.TableUtils;
+import com.j256.ormlite.core.stmt.UpdateBuilder;
+import com.j256.ormlite.core.support.ConnectionSource;
+import com.j256.ormlite.core.table.TableUtils;
 
 /**
  * Main sample routine to show how to define custom data persisters for tuning how ORMLite writes and reads stuff from

--- a/src/test/java/com/j256/ormlite/examples/datapersister/DateTimePersister.java
+++ b/src/test/java/com/j256/ormlite/examples/datapersister/DateTimePersister.java
@@ -2,18 +2,18 @@ package com.j256.ormlite.examples.datapersister;
 
 import org.joda.time.DateTime;
 
-import com.j256.ormlite.field.DataPersisterManager;
-import com.j256.ormlite.field.DatabaseField;
-import com.j256.ormlite.field.FieldType;
-import com.j256.ormlite.field.SqlType;
-import com.j256.ormlite.field.types.DateTimeType;
+import com.j256.ormlite.core.field.DataPersisterManager;
+import com.j256.ormlite.core.field.DatabaseField;
+import com.j256.ormlite.core.field.FieldType;
+import com.j256.ormlite.core.field.SqlType;
+import com.j256.ormlite.core.field.types.DateTimeType;
 
 /**
  * A custom persister that is able to store the Joda {@link DateTime} class in the database as epoch-millis long
  * integer. This overrides the {@link DateTimeType} which uses reflection instead. This should run faster.
  * 
  * This can be specified using {@link DatabaseField#persisterClass()} or registered with
- * {@link DataPersisterManager#registerDataPersisters(com.j256.ormlite.field.DataPersister...)}.
+ * {@link DataPersisterManager#registerDataPersisters(com.j256.ormlite.core.field.DataPersister...)}.
  * 
  * @author graywatson
  */

--- a/src/test/java/com/j256/ormlite/examples/datapersister/MyDatePersister.java
+++ b/src/test/java/com/j256/ormlite/examples/datapersister/MyDatePersister.java
@@ -4,11 +4,11 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.Date;
 
-import com.j256.ormlite.field.DatabaseField;
-import com.j256.ormlite.field.FieldType;
-import com.j256.ormlite.field.SqlType;
-import com.j256.ormlite.field.types.DateType;
-import com.j256.ormlite.support.DatabaseResults;
+import com.j256.ormlite.core.field.DatabaseField;
+import com.j256.ormlite.core.field.FieldType;
+import com.j256.ormlite.core.field.SqlType;
+import com.j256.ormlite.core.field.types.DateType;
+import com.j256.ormlite.core.support.DatabaseResults;
 
 /**
  * A custom persister that tweaks how the Date is stored in the database. If the date is before 1970 then this just

--- a/src/test/java/com/j256/ormlite/examples/datapersister/User.java
+++ b/src/test/java/com/j256/ormlite/examples/datapersister/User.java
@@ -4,9 +4,9 @@ import java.util.Date;
 
 import org.joda.time.DateTime;
 
-import com.j256.ormlite.field.DataPersisterManager;
-import com.j256.ormlite.field.DatabaseField;
-import com.j256.ormlite.table.DatabaseTable;
+import com.j256.ormlite.core.field.DataPersisterManager;
+import com.j256.ormlite.core.field.DatabaseField;
+import com.j256.ormlite.core.table.DatabaseTable;
 
 /**
  * Example user object that is persisted to disk by the DAO and other example classes.
@@ -32,7 +32,7 @@ public class User {
 	/**
 	 * NOTE: this is _not_ a default type that is stored by ORMLite so we are going to define a custom persister for
 	 * {@link DateTime} and register it using
-	 * {@link DataPersisterManager#registerDataPersisters(com.j256.ormlite.field.DataPersister...)}.
+	 * {@link DataPersisterManager#registerDataPersisters(com.j256.ormlite.core.field.DataPersister...)}.
 	 */
 	@DatabaseField
 	private DateTime createDateTime;

--- a/src/test/java/com/j256/ormlite/examples/fieldConfig/Delivery.java
+++ b/src/test/java/com/j256/ormlite/examples/fieldConfig/Delivery.java
@@ -2,8 +2,8 @@ package com.j256.ormlite.examples.fieldConfig;
 
 import java.util.Date;
 
-import com.j256.ormlite.field.DatabaseField;
-import com.j256.ormlite.field.DatabaseFieldConfig;
+import com.j256.ormlite.core.field.DatabaseField;
+import com.j256.ormlite.core.field.DatabaseFieldConfig;
 
 /**
  * Example delivery object that does not use any {@link DatabaseField} annotations but uses direct wiring of the field

--- a/src/test/java/com/j256/ormlite/examples/fieldConfig/FieldConfigMain.java
+++ b/src/test/java/com/j256/ormlite/examples/fieldConfig/FieldConfigMain.java
@@ -6,14 +6,14 @@ import static org.junit.Assert.assertNotNull;
 import java.util.ArrayList;
 import java.util.Date;
 
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.dao.DaoManager;
-import com.j256.ormlite.db.DatabaseType;
-import com.j256.ormlite.field.DatabaseFieldConfig;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.dao.DaoManager;
+import com.j256.ormlite.core.db.DatabaseType;
+import com.j256.ormlite.core.field.DatabaseFieldConfig;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.support.ConnectionSource;
-import com.j256.ormlite.table.DatabaseTableConfig;
-import com.j256.ormlite.table.TableUtils;
+import com.j256.ormlite.core.support.ConnectionSource;
+import com.j256.ormlite.core.table.DatabaseTableConfig;
+import com.j256.ormlite.core.table.TableUtils;
 
 /**
  * Main sample routine to show how to do basic operations with the package.

--- a/src/test/java/com/j256/ormlite/examples/foreign/Account.java
+++ b/src/test/java/com/j256/ormlite/examples/foreign/Account.java
@@ -1,7 +1,7 @@
 package com.j256.ormlite.examples.foreign;
 
-import com.j256.ormlite.field.DatabaseField;
-import com.j256.ormlite.table.DatabaseTable;
+import com.j256.ormlite.core.field.DatabaseField;
+import com.j256.ormlite.core.table.DatabaseTable;
 
 /**
  * Example account object that is persisted to disk by the DAO and other example classes.

--- a/src/test/java/com/j256/ormlite/examples/foreign/ForeignMain.java
+++ b/src/test/java/com/j256/ormlite/examples/foreign/ForeignMain.java
@@ -6,12 +6,12 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.dao.DaoManager;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.dao.DaoManager;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.stmt.QueryBuilder;
-import com.j256.ormlite.support.ConnectionSource;
-import com.j256.ormlite.table.TableUtils;
+import com.j256.ormlite.core.stmt.QueryBuilder;
+import com.j256.ormlite.core.support.ConnectionSource;
+import com.j256.ormlite.core.table.TableUtils;
 
 /**
  * Main sample routine to show how to do basic operations with the package.

--- a/src/test/java/com/j256/ormlite/examples/foreign/Order.java
+++ b/src/test/java/com/j256/ormlite/examples/foreign/Order.java
@@ -1,7 +1,7 @@
 package com.j256.ormlite.examples.foreign;
 
-import com.j256.ormlite.field.DatabaseField;
-import com.j256.ormlite.table.DatabaseTable;
+import com.j256.ormlite.core.field.DatabaseField;
+import com.j256.ormlite.core.table.DatabaseTable;
 
 /**
  * Example order object that is persisted to disk by the DAO and other example classes.

--- a/src/test/java/com/j256/ormlite/examples/foreignCollection/Account.java
+++ b/src/test/java/com/j256/ormlite/examples/foreignCollection/Account.java
@@ -1,9 +1,9 @@
 package com.j256.ormlite.examples.foreignCollection;
 
-import com.j256.ormlite.dao.ForeignCollection;
-import com.j256.ormlite.field.DatabaseField;
-import com.j256.ormlite.field.ForeignCollectionField;
-import com.j256.ormlite.table.DatabaseTable;
+import com.j256.ormlite.core.dao.ForeignCollection;
+import com.j256.ormlite.core.field.DatabaseField;
+import com.j256.ormlite.core.field.ForeignCollectionField;
+import com.j256.ormlite.core.table.DatabaseTable;
 
 /**
  * Example account object that is persisted to disk by the DAO and other example classes.

--- a/src/test/java/com/j256/ormlite/examples/foreignCollection/ForeignCollectionMain.java
+++ b/src/test/java/com/j256/ormlite/examples/foreignCollection/ForeignCollectionMain.java
@@ -7,13 +7,13 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import com.j256.ormlite.dao.CloseableIterator;
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.dao.DaoManager;
-import com.j256.ormlite.dao.ForeignCollection;
+import com.j256.ormlite.core.dao.CloseableIterator;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.dao.DaoManager;
+import com.j256.ormlite.core.dao.ForeignCollection;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.support.ConnectionSource;
-import com.j256.ormlite.table.TableUtils;
+import com.j256.ormlite.core.support.ConnectionSource;
+import com.j256.ormlite.core.table.TableUtils;
 
 /**
  * Main sample routine to show how to do basic operations with the package.

--- a/src/test/java/com/j256/ormlite/examples/foreignCollection/Order.java
+++ b/src/test/java/com/j256/ormlite/examples/foreignCollection/Order.java
@@ -1,7 +1,7 @@
 package com.j256.ormlite.examples.foreignCollection;
 
-import com.j256.ormlite.field.DatabaseField;
-import com.j256.ormlite.table.DatabaseTable;
+import com.j256.ormlite.core.field.DatabaseField;
+import com.j256.ormlite.core.table.DatabaseTable;
 
 /**
  * Example order object that is persisted to disk by the DAO and other example classes.

--- a/src/test/java/com/j256/ormlite/examples/manytomany/ManyToManyMain.java
+++ b/src/test/java/com/j256/ormlite/examples/manytomany/ManyToManyMain.java
@@ -5,14 +5,14 @@ import static org.junit.Assert.assertEquals;
 import java.sql.SQLException;
 import java.util.List;
 
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.dao.DaoManager;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.dao.DaoManager;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.stmt.PreparedQuery;
-import com.j256.ormlite.stmt.QueryBuilder;
-import com.j256.ormlite.stmt.SelectArg;
-import com.j256.ormlite.support.ConnectionSource;
-import com.j256.ormlite.table.TableUtils;
+import com.j256.ormlite.core.stmt.PreparedQuery;
+import com.j256.ormlite.core.stmt.QueryBuilder;
+import com.j256.ormlite.core.stmt.SelectArg;
+import com.j256.ormlite.core.support.ConnectionSource;
+import com.j256.ormlite.core.table.TableUtils;
 
 /**
  * Main sample routine to show how to do many-to-many type relationships. It also demonstrates how we user inner queries

--- a/src/test/java/com/j256/ormlite/examples/manytomany/Post.java
+++ b/src/test/java/com/j256/ormlite/examples/manytomany/Post.java
@@ -1,6 +1,6 @@
 package com.j256.ormlite.examples.manytomany;
 
-import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.core.field.DatabaseField;
 
 /**
  * Post to some blog with String content.

--- a/src/test/java/com/j256/ormlite/examples/manytomany/User.java
+++ b/src/test/java/com/j256/ormlite/examples/manytomany/User.java
@@ -1,6 +1,6 @@
 package com.j256.ormlite.examples.manytomany;
 
-import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.core.field.DatabaseField;
 
 /**
  * A user object with a name.

--- a/src/test/java/com/j256/ormlite/examples/manytomany/UserPost.java
+++ b/src/test/java/com/j256/ormlite/examples/manytomany/UserPost.java
@@ -1,6 +1,6 @@
 package com.j256.ormlite.examples.manytomany;
 
-import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.core.field.DatabaseField;
 
 /**
  * Join table which links users to their posts.

--- a/src/test/java/com/j256/ormlite/examples/simple/Account.java
+++ b/src/test/java/com/j256/ormlite/examples/simple/Account.java
@@ -1,7 +1,7 @@
 package com.j256.ormlite.examples.simple;
 
-import com.j256.ormlite.field.DatabaseField;
-import com.j256.ormlite.table.DatabaseTable;
+import com.j256.ormlite.core.field.DatabaseField;
+import com.j256.ormlite.core.table.DatabaseTable;
 
 /**
  * Example account object that is persisted to disk by the DAO and other example classes.

--- a/src/test/java/com/j256/ormlite/examples/simple/SimpleMain.java
+++ b/src/test/java/com/j256/ormlite/examples/simple/SimpleMain.java
@@ -12,15 +12,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.dao.DaoManager;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.dao.DaoManager;
 import com.j256.ormlite.jdbc.JdbcConnectionSource;
-import com.j256.ormlite.misc.TransactionManager;
-import com.j256.ormlite.stmt.PreparedQuery;
-import com.j256.ormlite.stmt.QueryBuilder;
-import com.j256.ormlite.stmt.SelectArg;
-import com.j256.ormlite.support.ConnectionSource;
-import com.j256.ormlite.table.TableUtils;
+import com.j256.ormlite.core.misc.TransactionManager;
+import com.j256.ormlite.core.stmt.PreparedQuery;
+import com.j256.ormlite.core.stmt.QueryBuilder;
+import com.j256.ormlite.core.stmt.SelectArg;
+import com.j256.ormlite.core.support.ConnectionSource;
+import com.j256.ormlite.core.table.TableUtils;
 
 /**
  * Main sample routine to show how to do basic operations with the package.

--- a/src/test/java/com/j256/ormlite/jdbc/DataSourceConnectionSourceTest.java
+++ b/src/test/java/com/j256/ormlite/jdbc/DataSourceConnectionSourceTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 
 import com.j256.ormlite.BaseJdbcTest;
 import com.j256.ormlite.db.H2DatabaseType;
-import com.j256.ormlite.support.DatabaseConnection;
+import com.j256.ormlite.core.support.DatabaseConnection;
 
 public class DataSourceConnectionSourceTest extends BaseJdbcTest {
 

--- a/src/test/java/com/j256/ormlite/jdbc/JdbcCompiledStatementTest.java
+++ b/src/test/java/com/j256/ormlite/jdbc/JdbcCompiledStatementTest.java
@@ -12,9 +12,9 @@ import java.sql.ResultSetMetaData;
 import org.easymock.EasyMock;
 import org.junit.Test;
 
-import com.j256.ormlite.BaseCoreTest;
-import com.j256.ormlite.field.SqlType;
-import com.j256.ormlite.stmt.StatementBuilder.StatementType;
+import com.j256.ormlite.core.BaseCoreTest;
+import com.j256.ormlite.core.field.SqlType;
+import com.j256.ormlite.core.stmt.StatementBuilder.StatementType;
 
 public class JdbcCompiledStatementTest extends BaseCoreTest {
 

--- a/src/test/java/com/j256/ormlite/jdbc/JdbcConnectionSourceTest.java
+++ b/src/test/java/com/j256/ormlite/jdbc/JdbcConnectionSourceTest.java
@@ -22,9 +22,9 @@ import java.util.Properties;
 
 import org.junit.Test;
 
-import com.j256.ormlite.BaseCoreTest;
+import com.j256.ormlite.core.BaseCoreTest;
 import com.j256.ormlite.db.H2DatabaseType;
-import com.j256.ormlite.support.DatabaseConnection;
+import com.j256.ormlite.core.support.DatabaseConnection;
 
 public class JdbcConnectionSourceTest extends BaseCoreTest {
 

--- a/src/test/java/com/j256/ormlite/jdbc/JdbcDatabaseConnectionTest.java
+++ b/src/test/java/com/j256/ormlite/jdbc/JdbcDatabaseConnectionTest.java
@@ -16,13 +16,13 @@ import java.sql.Types;
 import org.junit.Test;
 
 import com.j256.ormlite.BaseJdbcTest;
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.field.DatabaseField;
-import com.j256.ormlite.field.FieldType;
-import com.j256.ormlite.stmt.GenericRowMapper;
-import com.j256.ormlite.support.DatabaseConnection;
-import com.j256.ormlite.support.GeneratedKeyHolder;
-import com.j256.ormlite.table.DatabaseTable;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.field.DatabaseField;
+import com.j256.ormlite.core.field.FieldType;
+import com.j256.ormlite.core.stmt.GenericRowMapper;
+import com.j256.ormlite.core.support.DatabaseConnection;
+import com.j256.ormlite.core.support.GeneratedKeyHolder;
+import com.j256.ormlite.core.table.DatabaseTable;
 
 public class JdbcDatabaseConnectionTest extends BaseJdbcTest {
 

--- a/src/test/java/com/j256/ormlite/jdbc/JdbcDatabaseResultsTest.java
+++ b/src/test/java/com/j256/ormlite/jdbc/JdbcDatabaseResultsTest.java
@@ -19,7 +19,7 @@ import java.sql.Timestamp;
 
 import org.junit.Test;
 
-import com.j256.ormlite.BaseCoreTest;
+import com.j256.ormlite.core.BaseCoreTest;
 
 public class JdbcDatabaseResultsTest extends BaseCoreTest {
 

--- a/src/test/java/com/j256/ormlite/jdbc/JdbcPooledConnectionSourceTest.java
+++ b/src/test/java/com/j256/ormlite/jdbc/JdbcPooledConnectionSourceTest.java
@@ -14,14 +14,14 @@ import java.sql.SQLException;
 
 import org.junit.Test;
 
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.dao.DaoManager;
-import com.j256.ormlite.db.DatabaseType;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.dao.DaoManager;
+import com.j256.ormlite.core.db.DatabaseType;
 import com.j256.ormlite.db.DatabaseTypeUtils;
-import com.j256.ormlite.field.DatabaseField;
-import com.j256.ormlite.misc.IOUtils;
-import com.j256.ormlite.support.DatabaseConnection;
-import com.j256.ormlite.table.TableUtils;
+import com.j256.ormlite.core.field.DatabaseField;
+import com.j256.ormlite.core.misc.IOUtils;
+import com.j256.ormlite.core.support.DatabaseConnection;
+import com.j256.ormlite.core.table.TableUtils;
 
 public class JdbcPooledConnectionSourceTest {
 

--- a/src/test/java/com/j256/ormlite/jdbc/JdbcRawResultsImplTest.java
+++ b/src/test/java/com/j256/ormlite/jdbc/JdbcRawResultsImplTest.java
@@ -10,10 +10,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 
 import com.j256.ormlite.BaseJdbcTest;
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.dao.GenericRawResults;
-import com.j256.ormlite.dao.RawRowMapper;
-import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.dao.GenericRawResults;
+import com.j256.ormlite.core.dao.RawRowMapper;
+import com.j256.ormlite.core.field.DatabaseField;
 
 public class JdbcRawResultsImplTest extends BaseJdbcTest {
 

--- a/src/test/java/com/j256/ormlite/logger/Log4jLogTest.java
+++ b/src/test/java/com/j256/ormlite/logger/Log4jLogTest.java
@@ -1,5 +1,7 @@
 package com.j256.ormlite.logger;
 
+import com.j256.ormlite.core.logger.BaseLogTest;
+
 public class Log4jLogTest extends BaseLogTest {
 
 	public Log4jLogTest() {

--- a/src/test/java/com/j256/ormlite/misc/JdbcTransactionManagerTest.java
+++ b/src/test/java/com/j256/ormlite/misc/JdbcTransactionManagerTest.java
@@ -8,12 +8,13 @@ import static org.junit.Assert.fail;
 import java.sql.SQLException;
 import java.util.concurrent.Callable;
 
+import com.j256.ormlite.core.misc.TransactionManager;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.j256.ormlite.BaseJdbcTest;
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.field.DatabaseField;
 import com.j256.ormlite.jdbc.JdbcPooledConnectionSource;
 
 /**

--- a/src/test/java/com/j256/ormlite/spring/DaoFactoryTest.java
+++ b/src/test/java/com/j256/ormlite/spring/DaoFactoryTest.java
@@ -5,9 +5,9 @@ import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 
-import com.j256.ormlite.BaseCoreTest;
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.table.DatabaseTableConfig;
+import com.j256.ormlite.core.BaseCoreTest;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.table.DatabaseTableConfig;
 
 public class DaoFactoryTest extends BaseCoreTest {
 

--- a/src/test/java/com/j256/ormlite/spring/TableCreatorTest.java
+++ b/src/test/java/com/j256/ormlite/spring/TableCreatorTest.java
@@ -10,9 +10,9 @@ import java.util.List;
 import org.junit.Test;
 
 import com.j256.ormlite.BaseJdbcTest;
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.field.DatabaseField;
-import com.j256.ormlite.table.TableUtils;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.field.DatabaseField;
+import com.j256.ormlite.core.table.TableUtils;
 
 public class TableCreatorTest extends BaseJdbcTest {
 

--- a/src/test/java/com/j256/ormlite/stmt/JdbcQueryBuilderTest.java
+++ b/src/test/java/com/j256/ormlite/stmt/JdbcQueryBuilderTest.java
@@ -15,11 +15,15 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import com.j256.ormlite.core.stmt.PreparedQuery;
+import com.j256.ormlite.core.stmt.QueryBuilder;
+import com.j256.ormlite.core.stmt.SelectArg;
+import com.j256.ormlite.core.stmt.Where;
 import org.junit.Test;
 
 import com.j256.ormlite.BaseJdbcTest;
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.core.dao.Dao;
+import com.j256.ormlite.core.field.DatabaseField;
 
 public class JdbcQueryBuilderTest extends BaseJdbcTest {
 


### PR DESCRIPTION
Refers to https://github.com/j256/ormlite-jdbc/issues/31

Changes required to work with the changes of: https://github.com/j256/ormlite-core/pull/144

If 144 is accepted maybe it's better to also move here to have another top package, in this case which name would be a good one for the jdbc package? So that it doesn't look like `com.j256.ormlite.jdbc.jdbc`