### PR TITLE
Fixed exceptions in some JDBC drivers when working with chars

### DIFF
--- a/src/main/java/com/j256/ormlite/db/MariaDbDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/MariaDbDatabaseType.java
@@ -1,5 +1,11 @@
 package com.j256.ormlite.db;
 
+import com.j256.ormlite.field.DataPersister;
+import com.j256.ormlite.field.FieldConverter;
+import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.field.SqlType;
+import com.j256.ormlite.jdbc.CharacterCompatFieldConverter;
+
 /**
  * MariaDB database type information used to create the tables, etc.. It is an extension of MySQL.
  * 
@@ -24,5 +30,13 @@ public class MariaDbDatabaseType extends MysqlDatabaseType {
 	@Override
 	public String getDatabaseName() {
 		return DATABASE_NAME;
+	}
+
+	@Override
+	public FieldConverter getFieldConverter(DataPersister dataPersister, FieldType fieldType) {
+		if (dataPersister.getSqlType() == SqlType.CHAR)
+			return new CharacterCompatFieldConverter(dataPersister);
+
+		return super.getFieldConverter(dataPersister, fieldType);
 	}
 }

--- a/src/main/java/com/j256/ormlite/db/OracleDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/OracleDatabaseType.java
@@ -6,6 +6,7 @@ import com.j256.ormlite.field.DataPersister;
 import com.j256.ormlite.field.DataType;
 import com.j256.ormlite.field.FieldConverter;
 import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.jdbc.CharacterCompatFieldConverter;
 
 /**
  * Oracle database type information used to create the tables, etc..
@@ -100,8 +101,10 @@ public class OracleDatabaseType extends BaseDatabaseType {
 				if (BOOLEAN_INTEGER_FORMAT.equalsIgnoreCase(fieldType.getFormat())) {
 					return DataType.BOOLEAN_INTEGER.getDataPersister();
 				} else {
-					return DataType.BOOLEAN_CHAR.getDataPersister();
+					return new CharacterCompatFieldConverter(DataType.BOOLEAN_CHAR.getDataPersister());
 				}
+			case CHAR:
+				return new CharacterCompatFieldConverter(dataPersister);
 			default:
 				return super.getFieldConverter(dataPersister, fieldType);
 		}

--- a/src/main/java/com/j256/ormlite/db/SqlServerDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/db/SqlServerDatabaseType.java
@@ -8,6 +8,7 @@ import com.j256.ormlite.field.DataPersister;
 import com.j256.ormlite.field.FieldConverter;
 import com.j256.ormlite.field.FieldType;
 import com.j256.ormlite.field.SqlType;
+import com.j256.ormlite.jdbc.CharacterCompatFieldConverter;
 import com.j256.ormlite.support.DatabaseResults;
 
 /**
@@ -51,6 +52,8 @@ public class SqlServerDatabaseType extends BaseDatabaseType {
 				return booleanConverter;
 			case BYTE:
 				return byteConverter;
+			case CHAR:
+				return new CharacterCompatFieldConverter(dataType);
 			default:
 				return super.getFieldConverter(dataType, fieldType);
 		}

--- a/src/main/java/com/j256/ormlite/jdbc/CharacterCompatFieldConverter.java
+++ b/src/main/java/com/j256/ormlite/jdbc/CharacterCompatFieldConverter.java
@@ -1,0 +1,68 @@
+package com.j256.ormlite.jdbc;
+
+import com.j256.ormlite.field.BaseFieldConverter;
+import com.j256.ormlite.field.FieldConverter;
+import com.j256.ormlite.field.FieldType;
+import com.j256.ormlite.field.SqlType;
+import com.j256.ormlite.support.DatabaseResults;
+
+import java.sql.SQLException;
+
+/**
+ * Some drivers do not support setObject on Character objects!
+ */
+public class CharacterCompatFieldConverter extends BaseFieldConverter
+{
+	private FieldConverter wrappedConverter;
+
+	public CharacterCompatFieldConverter(FieldConverter wrappedConverter) {
+		this.wrappedConverter = wrappedConverter;
+	}
+
+	@Override
+	public SqlType getSqlType() {
+		return SqlType.CHAR;
+	}
+
+	@Override
+	public Object parseDefaultString(FieldType fieldType, String defaultStr) throws SQLException
+	{
+		Object character = wrappedConverter.parseDefaultString(fieldType, defaultStr);
+		if (character == null)
+			return null;
+		return character.toString(); // Convert to string
+	}
+
+	@Override
+	public Object javaToSqlArg(FieldType fieldType, Object obj) throws SQLException {
+		Object character = wrappedConverter.javaToSqlArg(fieldType, obj);
+		if (character == null)
+			return null;
+		return character.toString(); // Convert to string
+	}
+
+	@Override
+	public Object resultToSqlArg(FieldType fieldType, DatabaseResults results, int columnPos) throws SQLException {
+		return wrappedConverter.resultToSqlArg(fieldType, results, columnPos);
+	}
+
+	@Override
+	public Object resultToJava(FieldType fieldType, DatabaseResults results, int columnPos) throws SQLException {
+		return wrappedConverter.resultToJava(fieldType, results, columnPos);
+	}
+
+	@Override
+	public Object sqlArgToJava(FieldType fieldType, Object sqlArg, int columnPos) throws SQLException {
+		return wrappedConverter.sqlArgToJava(fieldType, sqlArg, columnPos);
+	}
+
+	@Override
+	public Object resultStringToJava(FieldType fieldType, String stringValue, int columnPos) throws SQLException {
+		return wrappedConverter.resultStringToJava(fieldType, stringValue, columnPos);
+	}
+
+	@Override
+	public Object makeConfigObject(FieldType fieldType) throws SQLException {
+		return wrappedConverter.makeConfigObject(fieldType);
+	}
+}


### PR DESCRIPTION
Not all JDBC drivers support `java.lang.Character` (for whatever reason). Notably MariaDB, Oracle and SQL Server. I've added a `FieldConverter` to convert the SQL arg into a String which is accepted by all 3 (+ 1 for JTDS) JDBC drivers. Note that the underlying SQL type remains unchanged so this should have no backwards compatibility concerns.

The new `CharacterCompatFieldConverter` currently resides in this repository but it should probably be moved into ormlite-core. Perhaps into a new package `com.j256.ormlite.field.converters` where we can also move `BooleanNumberFieldConverter` too (currently resides in `BaseDatabaseType`).

This fixes some exceptions first reported in issue #2.