### PR TITLE
Fix isCreateIndexIfNotExistsSupported() in MariaDbDatabaseType

### DIFF
--- a/src/main/java/com/j256/ormlite/jdbc/db/MariaDbDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/jdbc/db/MariaDbDatabaseType.java
@@ -50,4 +50,9 @@ public class MariaDbDatabaseType extends MysqlDatabaseType {
 			return super.getFieldConverter(dataPersister, fieldType);
 		}
 	}
+
+	@Override
+	public boolean isCreateIndexIfNotExistsSupported() {
+		return true;
+	}
 }


### PR DESCRIPTION
This PR should fix #71. As described there, MariaDB supports the creation of indexes using `IF NOT EXISTS`, unlike MySQL.