### PR TITLE
Fix PostgreSQL sequence creation error

### DIFF
--- a/src/main/java/com/j256/ormlite/jdbc/db/PostgresDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/jdbc/db/PostgresDatabaseType.java
@@ -59,7 +59,7 @@ public class PostgresDatabaseType extends BaseDatabaseType {
 		StringBuilder seqSb = new StringBuilder(64);
 		seqSb.append("CREATE SEQUENCE ");
 		// fix error when ORMLite tries to create an existing sequence
-		if (isCreateIfNotExistsSupported()) {
+		if (isCreateSequenceIfNotExistsSupported()) {
 			seqSb.append("IF NOT EXISTS ");
 		}
 		// when it is created, it needs to be escaped specially
@@ -136,5 +136,11 @@ public class PostgresDatabaseType extends BaseDatabaseType {
 	@Override
 	public boolean isSequenceNamesMustBeLowerCase() {
 		return true;
+	}
+
+	public boolean isCreateSequenceIfNotExistsSupported() {
+		int major = driver.getMajorVersion();
+		int minor = driver.getMinorVersion();
+		return major > 9 || (major == 9 && minor >= 5);
 	}
 }

--- a/src/main/java/com/j256/ormlite/jdbc/db/PostgresDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/jdbc/db/PostgresDatabaseType.java
@@ -58,6 +58,10 @@ public class PostgresDatabaseType extends BaseDatabaseType {
 		// needs to match dropColumnArg()
 		StringBuilder seqSb = new StringBuilder(64);
 		seqSb.append("CREATE SEQUENCE ");
+		// fix error when ORMLite tries to create an existing sequence
+		if (isCreateIfNotExistsSupported()) {
+			sb.append("IF NOT EXISTS ");
+		}
 		// when it is created, it needs to be escaped specially
 		appendEscapedEntityName(seqSb, sequenceName);
 		statementsBefore.add(seqSb.toString());

--- a/src/main/java/com/j256/ormlite/jdbc/db/PostgresDatabaseType.java
+++ b/src/main/java/com/j256/ormlite/jdbc/db/PostgresDatabaseType.java
@@ -60,7 +60,7 @@ public class PostgresDatabaseType extends BaseDatabaseType {
 		seqSb.append("CREATE SEQUENCE ");
 		// fix error when ORMLite tries to create an existing sequence
 		if (isCreateIfNotExistsSupported()) {
-			sb.append("IF NOT EXISTS ");
+			seqSb.append("IF NOT EXISTS ");
 		}
 		// when it is created, it needs to be escaped specially
 		appendEscapedEntityName(seqSb, sequenceName);


### PR DESCRIPTION
Sometimes, when application starts again (not firstly) and tries to create non-existing tables, then executing SQL sequences without `IF NOT EXISTS` flag that causes an exception (see a screenshot below).

![](https://i.imgur.com/XKo8F00.png)